### PR TITLE
Add -r flag to set PR_SET_CHILD_SUBREAPER

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ retrap
 ------
 ::
 
-    retrap [SRC:DST] [SRC:-] -- CMD [ARG...]
+    retrap [-r] [SRC:DST] [SRC:-] -- CMD [ARG...]
 
 retrap is a small program that spawns a subprocess and forwards remapped signals
 to it.
@@ -29,5 +29,8 @@ will ignore SIGPIPE, simply forwarding that on to its subprocess.
 
 The subprocess receives the parent process's standard input, output, and error
 file descriptors.
+
+The `-r` flag can be passed inside the signal list to make retrap act as
+subreaper for orphaned child processes.
 
 .. vim: set ft=rst tw=80 sw=4 ts=4 et :

--- a/subreaper_prctl.go
+++ b/subreaper_prctl.go
@@ -1,0 +1,9 @@
+// +build linux
+
+package main
+
+import "golang.org/x/sys/unix"
+
+func setSubreaper() error {
+	return unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
+}

--- a/subreaper_unsupported.go
+++ b/subreaper_unsupported.go
@@ -1,0 +1,12 @@
+// +build !linux
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func setSubreaper() error {
+	return fmt.Errorf("-r not supported on %s-%s", runtime.GOOS, runtime.GOARCH)
+}


### PR DESCRIPTION
This is mostly necessary for processes that do graceful reloads of
executables, such as caddy (and possibly nginx). Because caddy will
spawn a new executable and then the parent will die, this causes caddy
to be reparented to pid 1 (init). So, to keep the orphan process under
a process supervisor, it's necessary for either the supervisor to
implement subreaping (not always desirable, and creates a hard Linux
dependency) or to place a subreaper between the supervisor and the
child process.

Ordinarily I'd use izabera's pm-tools subreaper program for this, but
I can't have signals killing the subreaper itself. So, in this case,
it's necessary to trap all signals and foward them to the child process
instead of the subreaper handling them.

To support part of this, signals are now forwarded to the process group
instead of the direct child process, since it's necessary to send it to
reparented processes.

In addition, SIGCHLD is now always swallowed when it reaches retrap.

This is something that can be supported on other operating systems
(FreeBSD and DragonFly both have procctl and PROC_REAP_ACQUIRE), but
requires support from golang.org/x/sys/* for the system calls each
platform requires.